### PR TITLE
Add a `mirrors` parameter to `bison_register_toolchains`

### DIFF
--- a/bison/bison.bzl
+++ b/bison/bison.bzl
@@ -16,7 +16,7 @@
 
 load("@rules_bison//bison/internal:repository.bzl", _bison_repository = "bison_repository")
 load("@rules_bison//bison/internal:toolchain.bzl", _BISON_TOOLCHAIN_TYPE = "BISON_TOOLCHAIN_TYPE")
-load("@rules_bison//bison/internal:versions.bzl", "DEFAULT_VERSION", "check_version")
+load("@rules_bison//bison/internal:versions.bzl", "DEFAULT_VERSION", "DEFAULT_MIRRORS", "check_version")
 load("@rules_m4//m4:m4.bzl", "M4_TOOLCHAIN_TYPE")
 
 BISON_TOOLCHAIN_TYPE = _BISON_TOOLCHAIN_TYPE
@@ -26,7 +26,7 @@ def bison_toolchain(ctx):
     return ctx.toolchains[BISON_TOOLCHAIN_TYPE].bison_toolchain
 
 # buildifier: disable=unnamed-macro
-def bison_register_toolchains(version = DEFAULT_VERSION, extra_copts = []):
+def bison_register_toolchains(version = DEFAULT_VERSION, extra_copts = [], mirrors = DEFAULT_MIRRORS):
     check_version(version)
     repo_name = "bison_v{}".format(version)
     if repo_name not in native.existing_rules().keys():
@@ -34,6 +34,7 @@ def bison_register_toolchains(version = DEFAULT_VERSION, extra_copts = []):
             name = repo_name,
             version = version,
             extra_copts = extra_copts,
+            mirrors = mirrors,
         )
     native.register_toolchains("@rules_bison//bison/toolchains:v{}".format(version))
 

--- a/bison/internal/repository.bzl
+++ b/bison/internal/repository.bzl
@@ -18,6 +18,7 @@ load(
     "@rules_bison//bison/internal:versions.bzl",
     _VERSION_URLS = "VERSION_URLS",
     _check_version = "check_version",
+    _mirror_urls = "mirror_urls",
 )
 load(
     "@rules_bison//bison/internal:gnulib/gnulib.bzl",
@@ -95,7 +96,7 @@ def _bison_repository(ctx):
     source = _VERSION_URLS[version]
 
     ctx.download_and_extract(
-        url = source["urls"],
+        url = _mirror_urls(version, ctx.attr.mirrors),
         sha256 = source["sha256"],
         stripPrefix = "bison-{}".format(version),
     )
@@ -117,6 +118,7 @@ bison_repository = repository_rule(
     attrs = {
         "version": attr.string(mandatory = True),
         "extra_copts": attr.string_list(),
+        "mirrors": attr.string_list(),
         "_gnulib_build": attr.label(
             default = "@rules_bison//bison/internal:gnulib/gnulib.BUILD",
             allow_single_file = True,

--- a/bison/internal/versions.bzl
+++ b/bison/internal/versions.bzl
@@ -14,55 +14,46 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-_MIRRORS = [
-    "https://mirror.bazel.build/ftp.gnu.org/gnu/bison/",
+DEFAULT_MIRRORS = [
     "https://mirrors.kernel.org/gnu/bison/",
     "https://ftp.gnu.org/gnu/bison/",
 ]
 
-def _urls(filename):
-    return [m + filename for m in _MIRRORS]
+def mirror_urls(version, mirrors):
+    return ["{}/bison-{}.tar.xz".format(m, version) for m in mirrors]
 
 DEFAULT_VERSION = "3.3.2"
 
 VERSION_URLS = {
     "3.3.2": {
-        "urls": _urls("bison-3.3.2.tar.xz"),
         "sha256": "039ee45b61d95e5003e7e8376f9080001b4066ff357bde271b7faace53b9d804",
         "copyright_year": "2019",
     },
     "3.3.1": {
-        "urls": _urls("bison-3.3.1.tar.xz"),
         "sha256": "fd22fc5ed02b42c88fa0efc6d5de3face8dfb5e253bf97e632573413969bc900",
         "copyright_year": "2019",
     },
     "3.3": {
-        "urls": _urls("bison-3.3.tar.xz"),
         "sha256": "162ea71d21e134c44942f4ebb74685e19c942dcf40a7120eba165ba5e2553bb9",
         "copyright_year": "2019",
     },
     "3.2.4": {
-        "urls": _urls("bison-3.2.4.tar.xz"),
         "sha256": "523d44419f4df68286503740c95c7b3400b748d7d8b797209195ee5d67f05634",
         "copyright_year": "0000",
     },
     "3.2.3": {
-        "urls": _urls("bison-3.2.3.tar.xz"),
         "sha256": "3cb07a84ff698b205ea244e36eccb4979dd4e10f2120ebbf58c5f1f700023f29",
         "copyright_year": "0000",
     },
     "3.2.2": {
-        "urls": _urls("bison-3.2.2.tar.xz"),
         "sha256": "6f950f24e4d0745c7cc870e36d04f4057133ce0f31d6b4564e6f510a7d3ffafa",
         "copyright_year": "2018",
     },
     "3.2.1": {
-        "urls": _urls("bison-3.2.1.tar.xz"),
         "sha256": "8ba8bd5d6e935d01b89382fa5c2fa7602e03bbb435575087bfdc3c450d4d9ecd",
         "copyright_year": "0000",
     },
     "3.2": {
-        "urls": _urls("bison-3.2.tar.xz"),
         "sha256": "deec377b95aa72ec4e1a33fe2c938d2480749d740b5291a7cc1d77808d3710bf",
         "copyright_year": "0000",
     },


### PR DESCRIPTION
Allow mirrors to be configured when registering toolchains.